### PR TITLE
Allow adding environment variables to bots

### DIFF
--- a/lib/turbot_api/api.rb
+++ b/lib/turbot_api/api.rb
@@ -42,12 +42,12 @@ module Turbot
       request(:get, "/api/bots/#{bot_id}")
     end
 
-    def create_bot(bot_id, config)
-      request(:post, "/api/bots", :bot => {:bot_id => bot_id, :config => config})
+    def create_bot(bot_id, config, env = nil)
+      request(:post, "/api/bots", :bot => {:bot_id => bot_id, :config => config, :env => env})
     end
 
-    def update_bot(bot_id, config)
-      request(:put, "/api/bots/#{bot_id}", :bot => {:config => config})
+    def update_bot(bot_id, config, env = nil)
+      request(:put, "/api/bots/#{bot_id}", :bot => {:config => config, :env => env})
     end
 
     def show_manifest(bot_id)


### PR DESCRIPTION
Not included in config, as config is parsed from manifest.json normally, so we kept them separate. We'll do a PR on turbot_server to accept these and store them appropriately soon.
